### PR TITLE
Refs #97222; Handle case, when image is cached, and img.GET() returns…

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 12.0-dev0 - (unreleased)
 ---------------------
+* Bug fix: Don't try to scale if image is already cached in browser, 
+  just return 304 with empty string
+  [szabozo0 refs #97222]
 
 11.9 - (2018-06-20)
 ---------------------

--- a/eea/app/visualization/views/preview.py
+++ b/eea/app/visualization/views/preview.py
@@ -59,6 +59,12 @@ class PreviewImage(BrowserView):
         img = self.context.restrictedTraverse("++resource++" + self.__name__)
         scale = kwargs.get('scale', None)
         data = img.GET()
+        # 97222 img.GET() returns empty string with response code 304 if
+        # the request has the If-Modified-Since header
+        # we just return the same empty string with response code 304, because
+        # it means it's already cached in the browser
+        if data == '':
+            return data
         if not scale:
             return data
 


### PR DESCRIPTION
… empty string